### PR TITLE
re #10 - support for binary mode input files

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,34 @@ with requests.get('http://example.com/data.json', stream=True) as response:
     data = json_stream.requests.load(response)
 ```
 
+### Stream a URL (with visitor)
+
+#### urllib
+
+```python
+import urllib.request
+import json_stream
+
+def visitor(item, path):
+    print(f"{item} at path {path}")
+    
+with urllib.request.urlopen('http://example.com/data.json') as response:
+    json_stream.visit(response, visitor)
+```
+
+#### requests
+
+```python
+import requests
+import json_stream.requests
+
+def visitor(item, path):
+    print(f"{item} at path {path}")
+    
+with requests.get('http://example.com/data.json', stream=True) as response:
+    json_stream.requests.visit(response, visitor)
+```
+
 # Future improvements
 
 * Allow long strings in the JSON to be read as streams themselves

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = json-stream
-version = 1.1.0
+version = 1.2.0
 author = Jamie Cockburn
 author_email = jamie_cockburn@hotmail.co.uk
 description = Streaming JSON decoder
@@ -11,7 +11,7 @@ long_description_content_type = text/markdown
 project_urls =
     Bug Tracker = https://github.com/daggaz/json-stream/issues
 classifiers =
-    Development Status :: 3 - Alpha
+    Development Status :: 3 - Beta
     Intended Audience :: Developers
     Topic :: Software Development :: Libraries
     License :: OSI Approved :: MIT License

--- a/src/json_stream/requests/__init__.py
+++ b/src/json_stream/requests/__init__.py
@@ -21,6 +21,13 @@ class IterableStream(io.RawIOBase):
         return True
 
 
+def _to_file(response):
+    return io.BufferedReader(IterableStream(response.iter_content()))
+
+
 def load(response, persistent=False):
-    f = io.TextIOWrapper(io.BufferedReader(IterableStream(response.iter_content())))
-    return json_stream.load(f, persistent=persistent)
+    return json_stream.load(_to_file(response), persistent=persistent)
+
+
+def visit(response, visitor):
+    return json_stream.visit(_to_file(response), visitor)

--- a/src/json_stream/tests/test_loader.py
+++ b/src/json_stream/tests/test_loader.py
@@ -1,6 +1,6 @@
 import copy
 import json
-from io import StringIO
+from io import StringIO, BytesIO
 from itertools import zip_longest
 from unittest import TestCase
 
@@ -24,6 +24,11 @@ class TestLoader(TestCase):
         obj = {"a": 1, "b": None, "c": True}
         self._test_object(obj, persistent=True)
         self._test_object(obj, persistent=False)
+
+    def test_load_object_binary(self):
+        obj = {"a": 1, "b": None, "c": True}
+        self._test_object(obj, persistent=True, binary=True)
+        self._test_object(obj, persistent=False, binary=True)
 
     def test_load_object_get_persistent(self):
         json = '{"a": 1, "b": null, "c": true}'
@@ -212,18 +217,18 @@ class TestLoader(TestCase):
         with self.assertRaisesRegex(TransientAccessException, "Index 0 already passed in this stream"):
             _ = l[0]  # cannot access transient list
 
-    def _test_object(self, obj, persistent):
-        self.assertListEqual(list(self._to_data(obj, persistent)), list(obj))
-        self.assertListEqual(list(self._to_data(obj, persistent).keys()), list(obj.keys()))
-        self.assertListEqual(list(self._to_data(obj, persistent).values()), list(obj.values()))
-        self.assertListEqual(list(self._to_data(obj, persistent).items()), list(obj.items()))
+    def _test_object(self, obj, persistent, binary=False):
+        self.assertListEqual(list(self._to_data(obj, persistent, binary)), list(obj))
+        self.assertListEqual(list(self._to_data(obj, persistent, binary).keys()), list(obj.keys()))
+        self.assertListEqual(list(self._to_data(obj, persistent, binary).values()), list(obj.values()))
+        self.assertListEqual(list(self._to_data(obj, persistent, binary).items()), list(obj.items()))
         if persistent:
-            self.assertEqual(len(self._to_data(obj, persistent)), len(obj))
-        for k, expected_k in zip_longest(self._to_data(obj, persistent), obj):
+            self.assertEqual(len(self._to_data(obj, persistent, binary)), len(obj))
+        for k, expected_k in zip_longest(self._to_data(obj, persistent, binary), obj):
             self.assertEqual(k, expected_k)
 
         if not persistent:
-            data = self._to_data(obj, persistent)
+            data = self._to_data(obj, persistent, binary)
             iter(data)  # iterates first time
             with self.assertRaises(TransientAccessException):
                 iter(data)  # can't get second iterator
@@ -247,5 +252,10 @@ class TestLoader(TestCase):
             with self.assertRaises(TransientAccessException):
                 iter(data)  # can't get second iterator
 
-    def _to_data(self, obj, persistent):
-        return load(StringIO(json.dumps(obj)), persistent)
+    def _to_data(self, obj, persistent, binary=False):
+        data = json.dumps(obj)
+        if binary:
+            stream = BytesIO(data.encode())
+        else:
+            stream = StringIO(data)
+        return load(stream, persistent)

--- a/src/json_stream/tests/test_visitor.py
+++ b/src/json_stream/tests/test_visitor.py
@@ -1,14 +1,23 @@
-from io import StringIO
+from io import StringIO, BytesIO
 from unittest import TestCase
 
 import json_stream
 
 
 class TestVisitor(TestCase):
+    JSON = '{"x": 1, "y": {}, "xxxx": [1,2, {"yyyy": 1}, "z", 1, []]}'
+
     def test_visitor(self):
-        json = '{"x": 1, "y": {}, "xxxx": [1,2, {"yyyy": 1}, "z", 1, []]}'
         visited = []
-        json_stream.visit(StringIO(json), lambda a, b: visited.append((a, b)))
+        json_stream.visit(StringIO(self.JSON), lambda a, b: visited.append((a, b)))
+        self._assert_data_okay(visited)
+
+    def test_visitor_binary(self):
+        visited = []
+        json_stream.visit(BytesIO(self.JSON.encode()), lambda a, b: visited.append((a, b)))
+        self._assert_data_okay(visited)
+
+    def _assert_data_okay(self, visited):
         self.assertListEqual([
             (1, ('x',)),
             ({}, ('y',)),


### PR DESCRIPTION
The changes in PR test the input "file" to see if it returns `bytes` or `str` and wraps any byte-file in an `io.TextIOWrapper`. The encoding is used by the `TextIOWrapper` is guessed from:
* if it is a urllib-looking response, the `Content-Type` header encoding
* otherwise UTF-8