### PR TITLE
Add utility to convert to standard Python types

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,21 @@ with JSONStreamEncoder():
     some_library_function_out_of_your_control(data)
 ```
 
+### Converting to standard Python types
+
+To convert a json-stream `dict`-like or `list`-like object and all its
+descendants to a standard `list` and `dict`, you can use the
+`json_stream.to_standard_types` utility:
+
+```python
+# JSON: {"round": 1, "results": [1, 2, 3]}
+data = json_stream.load(f)
+results = data["results"]
+print(results)  # prints <TransientStreamingJSONList: TRANSIENT, STREAMING>
+converted = json_stream.to_standard_types(results)
+print(converted)  # prints [1, 2, 3]
+```
+
 #### Thread safety (experimental)
 
 There is also a thread-safe version of the `json.dump` context manager:

--- a/src/json_stream/__init__.py
+++ b/src/json_stream/__init__.py
@@ -1,2 +1,3 @@
 from json_stream.loader import load
 from json_stream.visitor import visit
+from json_stream.util import to_standard_types

--- a/src/json_stream/tests/test_util.py
+++ b/src/json_stream/tests/test_util.py
@@ -1,0 +1,15 @@
+from io import StringIO
+import json
+from unittest import TestCase
+
+import json_stream
+
+
+class TestToStandardTypes(TestCase):
+    JSON = '{"x": 1, "y": {}, "xxxx": [1,2, {"yyyy": 1}, "z", 1, []]}'
+
+    def test_to_standard_types(self):
+        js = json_stream.load(StringIO(self.JSON))
+        converted = json_stream.to_standard_types(js)
+        comparison = json.load(StringIO(self.JSON))
+        self.assertEqual(converted, comparison)

--- a/src/json_stream/util.py
+++ b/src/json_stream/util.py
@@ -1,0 +1,56 @@
+from collections import deque
+
+from json_stream.base import StreamingJSONList, StreamingJSONObject
+
+
+class Context:
+    LIST = 1
+    DICT = 2
+
+
+def to_standard_types(x):
+    in_stack, out_stack = deque(), deque()
+    if isinstance(x, StreamingJSONList):
+        in_stack.append((Context.LIST, iter(x)))
+        output = []
+    elif isinstance(x, StreamingJSONObject):
+        in_stack.append((Context.DICT, iter(x.items())))
+        output = {}
+    else:
+        return x
+    out_stack.append(output)
+    while len(in_stack) > 0:
+        try:
+            in_context, in_iter = in_stack[-1]
+            in_elem = next(in_iter)
+            if in_context == Context.LIST:
+                if isinstance(in_elem, StreamingJSONList):
+                    out_list = []
+                    out_stack[-1].append(out_list)
+                    out_stack.append(out_list)
+                    in_stack.append((Context.LIST, iter(in_elem)))
+                elif isinstance(in_elem, StreamingJSONObject):
+                    out_dict = {}
+                    out_stack[-1].append(out_dict)
+                    out_stack.append(out_dict)
+                    in_stack.append((Context.DICT, iter(in_elem.items())))
+                else:
+                    out_stack[-1].append(in_elem)
+            elif in_context == Context.DICT:
+                in_key, in_value = in_elem
+                if isinstance(in_value, StreamingJSONList):
+                    out_list = []
+                    out_stack[-1][in_key] = out_list
+                    out_stack.append(out_list)
+                    in_stack.append((Context.LIST, iter(in_value)))
+                elif isinstance(in_value, StreamingJSONObject):
+                    out_dict = {}
+                    out_stack[-1][in_key] = out_dict
+                    out_stack.append(out_dict)
+                    in_stack.append((Context.DICT, iter(in_value.items())))
+                else:
+                    out_stack[-1][in_key] = in_value
+        except StopIteration:
+            in_stack.pop()
+            out_stack.pop()
+    return output


### PR DESCRIPTION
Fixes #16.

Just a suggestion for how to do this in a non-recursive manner to allow use on arbitrarily deep structures.