### PR TITLE
Allow passing custom tokenizer to load/visit

### DIFF
--- a/src/json_stream/loader.py
+++ b/src/json_stream/loader.py
@@ -2,7 +2,7 @@ from json_stream.base import StreamingJSONBase
 from json_stream.tokenizer import tokenize
 
 
-def load(fp, persistent=False):
-    token_stream = tokenize(fp)
+def load(fp, persistent=False, tokenizer=tokenize):
+    token_stream = tokenizer(fp)
     _, token = next(token_stream)
     return StreamingJSONBase.factory(token, token_stream, persistent)

--- a/src/json_stream/visitor.py
+++ b/src/json_stream/visitor.py
@@ -18,8 +18,8 @@ def _visit(obj, visitor, path):
         visitor(obj, path)
 
 
-def visit(fp, visitor):
-    token_stream = tokenize(fp)
+def visit(fp, visitor, tokenizer=tokenize):
+    token_stream = tokenizer(fp)
     _, token = next(token_stream)
     obj = StreamingJSONBase.factory(token, token_stream, persistent=False)
     _visit(obj, visitor, ())


### PR DESCRIPTION
As discussed in #18.

If this was merged, I could get rid of the monkeypatching hack for `json-stream-rs-tokenizer`, which would then look like [this](https://github.com/smheidrich/py-json-stream-rs-tokenizer/tree/if-json-stream-supported-custom-tokenizer#usage).