### PR TITLE
Add chunk_size parameter to json_stream.requests.load and .visit to pass to requests' content reader.

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,11 @@ with requests.get('http://example.com/data.json', stream=True) as response:
     data = json_stream.requests.load(response)
 ```
 
+Function `load(Response)` uses `response.iter_content(chunk_size=10240)` under the hood to perform effective reads
+from the response stream and lower CPU usage. This default value has some implications if the server you read from
+sends responses of some fixed size and expects your reaction in-between. Make sure you check behaviour with
+`chunk_size=1` before filing any bugs.
+
 ### Stream a URL (with visitor)
 
 #### urllib
@@ -267,6 +272,8 @@ def visitor(item, path):
 with requests.get('http://example.com/data.json', stream=True) as response:
     json_stream.requests.visit(response, visitor)
 ```
+
+The `chunk_size` note applies to `visit()`, please see above.
 
 ### Encoding json-stream objects
 

--- a/src/json_stream/requests/__init__.py
+++ b/src/json_stream/requests/__init__.py
@@ -22,13 +22,13 @@ class IterableStream(io.RawIOBase):
         return True
 
 
-def _to_file(response):
-    return io.BufferedReader(IterableStream(response.iter_content()))
+def _to_file(response, chunk_size):
+    return io.BufferedReader(IterableStream(response.iter_content(chunk_size=chunk_size)))
 
 
-def load(response, persistent=False, tokenizer=default_tokenizer):
-    return json_stream.load(_to_file(response), persistent=persistent, tokenizer=tokenizer)
+def load(response, persistent=False, tokenizer=default_tokenizer, chunk_size=1):
+    return json_stream.load(_to_file(response, chunk_size), persistent=persistent, tokenizer=tokenizer)
 
 
-def visit(response, visitor, tokenizer=default_tokenizer):
-    return json_stream.visit(_to_file(response), visitor, tokenizer=tokenizer)
+def visit(response, visitor, tokenizer=default_tokenizer, chunk_size=1):
+    return json_stream.visit(_to_file(response, chunk_size), visitor, tokenizer=tokenizer)

--- a/src/json_stream/requests/__init__.py
+++ b/src/json_stream/requests/__init__.py
@@ -26,9 +26,9 @@ def _to_file(response, chunk_size):
     return io.BufferedReader(IterableStream(response.iter_content(chunk_size=chunk_size)))
 
 
-def load(response, persistent=False, tokenizer=default_tokenizer, chunk_size=1):
+def load(response, persistent=False, tokenizer=default_tokenizer, chunk_size=10240):
     return json_stream.load(_to_file(response, chunk_size), persistent=persistent, tokenizer=tokenizer)
 
 
-def visit(response, visitor, tokenizer=default_tokenizer, chunk_size=1):
+def visit(response, visitor, tokenizer=default_tokenizer, chunk_size=10240):
     return json_stream.visit(_to_file(response, chunk_size), visitor, tokenizer=tokenizer)


### PR DESCRIPTION
When used without parameters requests' content iterator using chunk size of 1. I don't know what the measure of chunk unit is, but from the code I can tell it is bytes. So we're reading 1 byte (!!!) per call. This makes json_stream extremely slow on streaming requests. If you put chunk_size bigger than around 1K it can easily speed up parsing by a factor of 5.

Or should we just hardcode chunk_size to something like 65K inside `_to_file`?

I don't see any noticeable memory consumption increase.

A quick benchmark of streaming requests, getting JSON from https://pypi.org/simple/ and parsing it:

```python
import requests
import json_stream
import json_stream.requests
import json

url = 'https://pypi.org/simple/'
headers = {"Accept": "application/vnd.pypi.simple.v1+json"}

def nostream_request_vanilla_json():
    with requests.get(url, headers=headers) as resp:
        data = json.loads(resp.content)
        for project in data['projects']:
            print(project['name'])

def stream_request_json_stream():
    with requests.get(url, headers=headers, stream=True) as resp:
        data = json_stream.requests.load(resp)
        for project in data['projects']:
            print(project['name'])
```

* no-streaming request + vanilla json: 2.1 sec
* streaming request + json_stream with chunk_size 1: 28.1 sec
* streaming request + json_stream with chunk_size 65536: 5.1 sec