### PR TITLE
Raise error on unterminated string at EOF

### DIFF
--- a/src/json_stream/base.py
+++ b/src/json_stream/base.py
@@ -13,6 +13,8 @@ class TransientAccessException(Exception):
 
 
 class StreamingJSONBase(ABC):
+    INCOMPLETE_ERROR = "Unexpected end of file"
+
     @classmethod
     def factory(cls, token, token_stream, persistent):
         if persistent:
@@ -47,6 +49,8 @@ class StreamingJSONBase(ABC):
             try:
                 item = self._load_item()
             except StopIteration:
+                if self.streaming:
+                    raise ValueError(self.INCOMPLETE_ERROR)
                 return
             yield item
 
@@ -134,6 +138,8 @@ class TransientStreamingJSONBase(StreamingJSONBase, ABC):
 
 
 class StreamingJSONList(StreamingJSONBase, ABC):
+    INCOMPLETE_ERROR = "Unterminated list at end of file"
+
     def _load_item(self):
         token_type, v = next(self._stream)
         if token_type == TokenType.OPERATOR:
@@ -198,6 +204,8 @@ class TransientStreamingJSONList(TransientStreamingJSONBase, StreamingJSONList):
 
 
 class StreamingJSONObject(StreamingJSONBase, ABC):
+    INCOMPLETE_ERROR = "Unterminated object at end of file"
+
     def _load_item(self):
         token_type, k = next(self._stream)
         if token_type == TokenType.OPERATOR:

--- a/src/json_stream/tests/test_loader.py
+++ b/src/json_stream/tests/test_loader.py
@@ -214,3 +214,23 @@ class TestLoader(JSONLoadTestCase):
         self.assertEqual(data["b"], 2)  # would error if data was transient
         with self.assertRaisesRegex(TransientAccessException, "Index 0 already passed in this stream"):
             _ = list_[0]  # cannot access transient list
+
+    def test_unterminated_list(self):
+        with self.assertRaisesRegex(ValueError, "Unterminated list at end of file"):
+            load(StringIO('[')).read_all()
+        with self.assertRaisesRegex(ValueError, "Unterminated list at end of file"):
+            load(StringIO('[1')).read_all()
+        with self.assertRaisesRegex(ValueError, "Unterminated list at end of file"):
+            load(StringIO('[1,')).read_all()
+
+    def test_unterminated_object(self):
+        with self.assertRaisesRegex(ValueError, "Unterminated object at end of file"):
+            load(StringIO('{')).read_all()
+        with self.assertRaisesRegex(ValueError, "Unterminated object at end of file"):
+            load(StringIO('{"x"')).read_all()
+        with self.assertRaisesRegex(ValueError, "Unterminated object at end of file"):
+            load(StringIO('{"x":')).read_all()
+        with self.assertRaisesRegex(ValueError, "Unterminated object at end of file"):
+            load(StringIO('{"x": 1')).read_all()
+        with self.assertRaisesRegex(ValueError, "Unterminated object at end of file"):
+            load(StringIO('{"x": 1,')).read_all()

--- a/src/json_stream/tests/test_tokenizer.py
+++ b/src/json_stream/tests/test_tokenizer.py
@@ -8,8 +8,6 @@ Copyright (c) 2019 Daniel Yule
 from io import StringIO
 from unittest import TestCase
 
-import pytest
-
 from json_stream.tokenizer import tokenize, TokenType
 
 
@@ -88,10 +86,6 @@ class TestJsonTokenization(TestCase):
         self.assertRaises(ValueError, self.tokenize_sequence, "\"\\!\"")
         self.assertRaises(ValueError, self.tokenize_sequence, "\"\\u!\"")
 
-    @pytest.mark.xfail(
-        reason="https://github.com/daggaz/json-stream/issues/35",
-        strict=True,
-    )
     def test_unterminated_strings(self):
         self.assertRaises(ValueError, self.tokenize_sequence, "'unterminated")
         self.assertRaises(ValueError, self.tokenize_sequence, '"unterminated')

--- a/src/json_stream/tests/test_tokenizer.py
+++ b/src/json_stream/tests/test_tokenizer.py
@@ -87,7 +87,8 @@ class TestJsonTokenization(TestCase):
         self.assertRaises(ValueError, self.tokenize_sequence, "\"\\u!\"")
 
     def test_unterminated_strings(self):
-        self.assertRaises(ValueError, self.tokenize_sequence, '"unterminated')
+        with self.assertRaisesRegex(ValueError, "Unterminated string at end of file"):
+            self.tokenize_sequence('"unterminated')
 
     def test_sequence(self):
         result = [token for token in tokenize(StringIO("123 \"abc\":{}"))]

--- a/src/json_stream/tests/test_tokenizer.py
+++ b/src/json_stream/tests/test_tokenizer.py
@@ -87,7 +87,6 @@ class TestJsonTokenization(TestCase):
         self.assertRaises(ValueError, self.tokenize_sequence, "\"\\u!\"")
 
     def test_unterminated_strings(self):
-        self.assertRaises(ValueError, self.tokenize_sequence, "'unterminated")
         self.assertRaises(ValueError, self.tokenize_sequence, '"unterminated')
 
     def test_sequence(self):

--- a/src/json_stream/tests/test_tokenizer.py
+++ b/src/json_stream/tests/test_tokenizer.py
@@ -8,6 +8,8 @@ Copyright (c) 2019 Daniel Yule
 from io import StringIO
 from unittest import TestCase
 
+import pytest
+
 from json_stream.tokenizer import tokenize, TokenType
 
 
@@ -85,6 +87,14 @@ class TestJsonTokenization(TestCase):
         self.assertRaises(ValueError, self.tokenize_sequence, "\"\\2\"")
         self.assertRaises(ValueError, self.tokenize_sequence, "\"\\!\"")
         self.assertRaises(ValueError, self.tokenize_sequence, "\"\\u!\"")
+
+    @pytest.mark.xfail(
+        reason="https://github.com/daggaz/json-stream/issues/35",
+        strict=True,
+    )
+    def test_unterminated_strings(self):
+        self.assertRaises(ValueError, self.tokenize_sequence, "'unterminated")
+        self.assertRaises(ValueError, self.tokenize_sequence, '"unterminated')
 
     def test_sequence(self):
         result = [token for token in tokenize(StringIO("123 \"abc\":{}"))]


### PR DESCRIPTION
Resolves part (or all?) of the issue mentioned in #35, but only for the Python tokenizer, of course.

Corresponding PR for the Rust tokenizer: https://github.com/smheidrich/py-json-stream-rs-tokenizer/pull/55

Also adds new test case for this.